### PR TITLE
Fixing the no confounding method

### DIFF
--- a/R/dispatch-simulations.R
+++ b/R/dispatch-simulations.R
@@ -17,7 +17,7 @@
 #'     be run in parallel.
 #' @param failure It is uncleear what this does. Max or Beth, do you happen to know the story behind this parameter?
 #' @param verbose Default TRUE. IF TRUE, provides details on what's currently running.
-#' @param ... additional parameters to be passed to future_apply.
+#' @param ... additional parameters to be passed to future_apply. User can pass future.globals and future.packages if your code relies on additrional packages
 #' 
 #' @importFrom future.apply future_lapply
 #' @importFrom stats simulate

--- a/R/optic-simulation-helper.R
+++ b/R/optic-simulation-helper.R
@@ -54,12 +54,13 @@
 #' 
 optic_simulation <- function(x, models, iters,
                              unit_var, time_var, 
-                             effect_magnitude, n_units, 
+                             effect_magnitude, 
+                             n_units, 
                              effect_direction, 
                              policy_speed, 
-                             n_implementation_periods,
                              prior_control,
                              treat_var,
+                             n_implementation_periods,
                              rhos, years_apart, ordered,
                              method,
                              method_sample, method_model, method_results,     
@@ -178,7 +179,7 @@ optic_simulation <- function(x, models, iters,
   stopifnot(is.numeric(n_units))
   stopifnot(all(effect_direction %in% c("null", "neg", "pos")))
   stopifnot(all(policy_speed %in% c("instant", "slow")))
-  #stopifnot(is.numeric(n_implementation_periods))
+  stopifnot(is.numeric(n_implementation_periods))
   
   # Crete list with mandatory parameters
   params <- list(unit_var = unit_var,
@@ -209,6 +210,8 @@ optic_simulation <- function(x, models, iters,
   if(!missing(treat_var)) {
     params$treat_var <- treat_var
   }
+  
+  dput(params)
   
   ###
   # create a OpticSim object

--- a/R/optic-simulation-helper.R
+++ b/R/optic-simulation-helper.R
@@ -25,6 +25,8 @@
 #' @param n_units integer. document.
 #' @param effect_direction character vector containing the effects direction to consider. can include "null", "pos" and/or "neg"
 #' @param policy_speed document. either "instant" or "slow"
+#' @param prior_control character(n) document. apparently only used for no_confounding
+#' @param treat_var character(1). document. apparently only used for no_confounding.
 #' @param n_implementation_periods document
 #' @param rhos document
 #' @param years_apart document
@@ -55,7 +57,10 @@ optic_simulation <- function(x, models, iters,
                              effect_magnitude, n_units, 
                              effect_direction, 
                              policy_speed, 
-                             n_implementation_periods, rhos, years_apart, ordered,
+                             n_implementation_periods,
+                             prior_control,
+                             treat_var,
+                             rhos, years_apart, ordered,
                              method,
                              method_sample, method_model, method_results,     
                              method_pre_model, method_post_model, 
@@ -92,14 +97,23 @@ optic_simulation <- function(x, models, iters,
     d_method_model= concurrent_model
     d_method_post_model= concurrent_postmodel
     d_method_results= concurrent_results
+    
+    # Check method-specific inputs:
+    stopifnot(is.numeric(years_apart))
+    stopifnot(is.numeric(rhos))
+    stopifnot(is.logical(ordered))
+    
   } else if (method == "no_confounding") {
+    stopifnot(prior_control %in% c("mva3", "trend"))
+    stopifnot(is.character(treat_var))
     d_method_sample = noconf_sample
     d_method_pre_model = noconf_premodel
     d_method_model = noconf_model
     d_method_post_model = noconf_postmodel
     d_method_results = noconf_results
   } else if (method == "confounding") {
-    stop("Confounding is currently not implemented.")
+    #stop("Confounding is currently not implemented.")
+    # Here, assign confounding methods once they are implemented
     # Uncomment once we bring the confounding code to the package.
     #d_method_sample = conf_sample
     #d_method_pre_model = conf_premodel
@@ -161,23 +175,40 @@ optic_simulation <- function(x, models, iters,
   stopifnot(is.character(unit_var), length(unit_var) == 1)
   stopifnot(is.character(time_var), length(time_var) == 1)
   stopifnot(is.list(effect_magnitude))
-  stopifnot(is.numeric(n_units), length(n_units) == 1)
+  stopifnot(is.numeric(n_units))
   stopifnot(all(effect_direction %in% c("null", "neg", "pos")))
   stopifnot(all(policy_speed %in% c("instant", "slow")))
-  stopifnot(is.numeric(n_implementation_periods))
-  stopifnot(is.numeric(rhos))
-  stopifnot(is.logical(ordered))
+  #stopifnot(is.numeric(n_implementation_periods))
   
+  # Crete list with mandatory parameters
   params <- list(unit_var = unit_var,
                  time_var = time_var,
                  effect_magnitude = effect_magnitude,
                  n_units = n_units,
                  effect_direction = effect_direction,
-                 policy_speed = policy_speed,
-                 n_implementation_periods = n_implementation_periods,
-                 rhos = rhos,
-                 years_apart = years_apart,
-                 ordered = ordered)
+                 policy_speed = policy_speed)
+  
+  # Add method-specific parameters if they are provided:
+  
+  if(!missing(rhos)) {
+    params$rhos <- rhos
+  }
+  
+  if(!missing(years_apart)) {
+    params$years_apart <- years_apart
+  }
+  
+  if(!missing(ordered)) {
+    params$ordered <- ordered
+  }
+  
+  if(!missing(prior_control)) {
+    params$prior_control <- prior_control
+  }
+  
+  if(!missing(treat_var)) {
+    params$treat_var <- treat_var
+  }
   
   ###
   # create a OpticSim object

--- a/R/optic-simulation-helper.R
+++ b/R/optic-simulation-helper.R
@@ -187,7 +187,8 @@ optic_simulation <- function(x, models, iters,
                  effect_magnitude = effect_magnitude,
                  n_units = n_units,
                  effect_direction = effect_direction,
-                 policy_speed = policy_speed)
+                 policy_speed = policy_speed,
+                 n_implementation_periods = n_implementation_periods)
   
   # Add method-specific parameters if they are provided:
   
@@ -210,8 +211,6 @@ optic_simulation <- function(x, models, iters,
   if(!missing(treat_var)) {
     params$treat_var <- treat_var
   }
-  
-  dput(params)
   
   ###
   # create a OpticSim object

--- a/dev/dev_test_concurrent.R
+++ b/dev/dev_test_concurrent.R
@@ -1,5 +1,5 @@
 
-#devtools::document()
+devtools::document()
 #devtools::build_manual()
 devtools::load_all()
 

--- a/dev/dev_test_concurrent.R
+++ b/dev/dev_test_concurrent.R
@@ -1,8 +1,9 @@
 
-devtools::document()
+#devtools::document()
+#devtools::build_manual()
 devtools::load_all()
 
-# library(optic)
+#library(optic)
 # Question: Call "example_data" something else. opioid_deaths?
 # 
 data(overdoses)
@@ -35,45 +36,29 @@ model_2 <- optic_model(name="autoreg_linear",
               weights= as.name("population"),
               se_adjust=c("none", "cluster"))
 
-
-# TODO: Look at current script and implement combinations of type and call.
-# Name is arbitrary.
-# type
-# In the manual, describe how to use count models as well?
-# r
-# sim_config
-# there's also feols, multisynth. check by searching model_type == 
-
-
-# TODO: question
-# Do we need model_type AND model_call?
-# Probably not?
-
-# TODO: There are some code dependent on the data.
-# outcome_count (deaths), outcome_rate (crude.rate)
-# Covariates / Balanced Statistics?
-# Balanced table.
+# Test optic_simulation
 
 optic_sim <- optic_simulation(
   x=overdoses,
   models=list(model_1, model_2),
-  iters=10,
+  iters=2,
   method = "concurrent",
   unit_var="state",
   time_var="year",
   effect_magnitude=list(scenario1, scenario2),
-  n_units=c(30),
+  n_units=c(10),
   effect_direction=c("null", "neg"),
   policy_speed=c("instant", "slow"),
   n_implementation_periods=c(3),
-  rhos=c(0, 0.25, 0.5, 0.75, 0.9),
+  rhos=c(0, 0.5, 0.9),
   years_apart=2,
   ordered=TRUE
 )
 
+# future.globals and future.packages may be needed on windows machines.
 lm_results <- dispatch_simulations(
   optic_sim,
-  use_future=T,
+  use_future=F,
   seed=9782,
   verbose=2,
   future.globals=c("cluster_adjust_se"),
@@ -81,4 +66,6 @@ lm_results <- dispatch_simulations(
 )
 
 ## look at code that generates that test the 
+
+do.call(rbind, lm_results)
 

--- a/dev/dev_test_no_confounding.R
+++ b/dev/dev_test_no_confounding.R
@@ -39,7 +39,7 @@ fixedeff_linear <- optic_model(
 )
 
 
-linear_fe_config <- optic_simulation(
+no_confounding_fe_config <- optic_simulation(
   # data and models required
   x=modified_data,
   models=list(fixedeff_linear),
@@ -60,8 +60,8 @@ linear_fe_config <- optic_simulation(
 )
 
 
-linear_results <- dispatch_simulations(
-  linear_fe_config,
+no_confounding_results <- dispatch_simulations(
+  no_confounding_fe_config,
   use_future=F,
   seed=9782,
   verbose=2,
@@ -69,4 +69,14 @@ linear_results <- dispatch_simulations(
   future.packages=c("MASS", "dplyr", "optic")
 )
 
-linear_results_df <- do.call(rbind, linear_results)
+no_confounding_results_df <- do.call(rbind, no_confounding_results) %>% as.data.frame()
+
+
+test_that("no_confounding simulations work", {
+  
+  expect_type(no_confounding_results, "list")
+  
+  expect_false(any(is.na(no_confounding_results_df)))
+  
+})
+

--- a/dev/dev_test_no_confounding.R
+++ b/dev/dev_test_no_confounding.R
@@ -1,0 +1,72 @@
+
+
+devtools::load_all()
+# library(optic)
+
+data(overdoses)
+
+# Test Based on an old README file left by Adam
+# Not sure this is the best example but it works
+
+modified_data <- overdoses %>%
+                    arrange(state, year) %>%
+                      group_by(state) %>%
+                      mutate(lag1 = lag(opioid_rx, n=1L),
+                             lag2 = lag(opioid_rx, n=2L),
+                             lag3 = lag(opioid_rx, n=3L)) %>%
+                      ungroup() %>%
+                      rowwise() %>%
+                      # code in moving average and trend versions of prior control
+                      mutate(prior_control_mva3_OLD = mean(c(lag1, lag2, lag3)),
+                             prior_control_trend_OLD = lag1 - lag3) %>%
+                      ungroup() %>%
+                      dplyr::select(-lag1, -lag2, -lag3) %>%
+                      mutate(state = factor(as.character(state)))
+
+linear0 <- 0
+linear5 <- .05*mean(modified_data$opioid_rx, na.rm=T)
+linear15 <- .15*mean(modified_data$opioid_rx, na.rm=T)
+linear25 <- .25*mean(modified_data$opioid_rx, na.rm=T)
+
+
+fixedeff_linear <- optic_model(
+  name="fixedeff_linear",
+  type="reg",
+  call="lm",
+  formula=opioid_rx ~ treatment_level + unemploymentrate + as.factor(year) + as.factor(state),
+  weights=as.name("population"),
+  se_adjust=c("none", "cluster")
+)
+
+
+linear_fe_config <- optic_simulation(
+  # data and models required
+  x=modified_data,
+  models=list(fixedeff_linear),
+  # iterations
+  iters=50, # 5000
+  # specify functions or S3 class of set of functions
+  method = "no_confounding",
+  globals=NULL,
+  unit_var="state",
+  treat_var="state",
+  time_var="year",
+  effect_magnitude=list(linear0, linear5), # linear15, linear25),
+  n_units= c(5), # c(1, 5, 15, 30), #2%, 10%, 30%, 60%
+  effect_direction=c("neg"),
+  policy_speed=list("instant"),
+  n_implementation_periods=c(0), 
+  prior_control=c("mva3", "trend")
+)
+
+
+linear_results <- dispatch_simulations(
+  linear_fe_config,
+  use_future=F,
+  seed=9782,
+  verbose=2,
+  future.globals=c("cluster_adjust_se"),
+  future.packages=c("MASS", "dplyr", "optic")
+)
+
+

--- a/dev/dev_test_no_confounding.R
+++ b/dev/dev_test_no_confounding.R
@@ -69,4 +69,4 @@ linear_results <- dispatch_simulations(
   future.packages=c("MASS", "dplyr", "optic")
 )
 
-
+linear_results_df <- do.call(rbind, linear_results)

--- a/man/dispatch_simulations.Rd
+++ b/man/dispatch_simulations.Rd
@@ -27,7 +27,7 @@ be run in parallel.}
 
 \item{verbose}{Default TRUE. IF TRUE, provides details on what's currently running.}
 
-\item{...}{additional parameters to be passed to future_apply.}
+\item{...}{additional parameters to be passed to future_apply. User can pass future.globals and future.packages if your code relies on additrional packages}
 }
 \description{
 Execute simulations defined in a optic_simulation object

--- a/man/optic_simulation.Rd
+++ b/man/optic_simulation.Rd
@@ -14,6 +14,8 @@ optic_simulation(
   n_units,
   effect_direction,
   policy_speed,
+  prior_control,
+  treat_var,
   n_implementation_periods,
   rhos,
   years_apart,
@@ -47,6 +49,10 @@ The elements must be created using the `optic_model` function.}
 \item{effect_direction}{character vector containing the effects direction to consider. can include "null", "pos" and/or "neg"}
 
 \item{policy_speed}{document. either "instant" or "slow"}
+
+\item{prior_control}{character(n) document. apparently only used for no_confounding}
+
+\item{treat_var}{character(1). document. apparently only used for no_confounding.}
 
 \item{n_implementation_periods}{document}
 

--- a/tests/testthat/test-concurrent.R
+++ b/tests/testthat/test-concurrent.R
@@ -6,7 +6,7 @@
 # See README.md for information on usage and licensing
 #------------------------------------------------------------------------------#
 
-# Testing the base case of the package:
+# Testing an example of the concurrent method.
 
 data(overdoses)
 x <- overdoses
@@ -79,10 +79,10 @@ concurrent_results_list <- dispatch_simulations(
 
 concurrent_results <- do.call(rbind, concurrent_results_list) %>% as.data.frame()
 
-test_that("simulation results seem sensible", {
+test_that("concurrent simulations work", {
   
   expect_type(concurrent_results_list, "list")
-
+  
   expect_false(any(is.na(concurrent_results)))
   
 })

--- a/tests/testthat/test-no_confounding.R
+++ b/tests/testthat/test-no_confounding.R
@@ -1,0 +1,77 @@
+
+
+
+#------------------------------------------------------------------------------#
+# OPTIC R Package Code Repository
+# Copyright (C) 2023 by The RAND Corporation
+# See README.md for information on usage and licensing
+#------------------------------------------------------------------------------#
+
+# Testing an example of the no_confounding method
+
+
+data(overdoses)
+
+# Test based on an old README file left by Adam
+
+modified_data <- overdoses %>%
+  arrange(state, year) %>%
+  group_by(state) %>%
+  mutate(lag1 = lag(opioid_rx, n=1L),
+         lag2 = lag(opioid_rx, n=2L),
+         lag3 = lag(opioid_rx, n=3L)) %>%
+  ungroup() %>%
+  rowwise() %>%
+  # code in moving average and trend versions of prior control
+  mutate(prior_control_mva3_OLD = mean(c(lag1, lag2, lag3)),
+         prior_control_trend_OLD = lag1 - lag3) %>%
+  ungroup() %>%
+  dplyr::select(-lag1, -lag2, -lag3) %>%
+  mutate(state = factor(as.character(state)))
+
+linear0 <- 0
+linear5 <- .05*mean(modified_data$opioid_rx, na.rm=T)
+linear15 <- .15*mean(modified_data$opioid_rx, na.rm=T)
+linear25 <- .25*mean(modified_data$opioid_rx, na.rm=T)
+
+
+fixedeff_linear <- optic_model(
+  name="fixedeff_linear",
+  type="reg",
+  call="lm",
+  formula=opioid_rx ~ treatment_level + unemploymentrate + as.factor(year) + as.factor(state),
+  weights=as.name("population"),
+  se_adjust=c("none", "cluster")
+)
+
+
+linear_fe_config <- optic_simulation(
+  # data and models required
+  x=modified_data,
+  models=list(fixedeff_linear),
+  # iterations
+  iters=5, # 5000
+  # specify functions or S3 class of set of functions
+  method = "no_confounding",
+  globals=NULL,
+  unit_var="state",
+  treat_var="state",
+  time_var="year",
+  effect_magnitude=list(linear0, linear5), # linear15, linear25),
+  n_units= c(5), # c(1, 5, 15, 30), #2%, 10%, 30%, 60%
+  effect_direction=c("neg"),
+  policy_speed=list("instant"),
+  n_implementation_periods=c(0), 
+  prior_control=c("mva3", "trend")
+)
+
+linear_results <- dispatch_simulations(
+  linear_fe_config,
+  use_future=T,
+  seed=9782,
+  verbose=2,
+  future.globals=c("cluster_adjust_se"),
+  future.packages=c("MASS", "dplyr", "optic")
+)
+
+linear_results_df <- do.call(rbind, linear_results)


### PR DESCRIPTION
The main issue was that we were not passing no-confounding-specific parameters to the optic_simulation object, and the no_confounding code required some data manipulation that was not done in our naive previous test.